### PR TITLE
Fix compilation for C++20

### DIFF
--- a/jsi/jsi/test/testlib.cpp
+++ b/jsi/jsi/test/testlib.cpp
@@ -50,7 +50,8 @@ TEST_P(JSITest, PropNameIDTest) {
       rt, movedQuux, PropNameID::forAscii(rt, std::string("foo"))));
   uint8_t utf8[] = {0xF0, 0x9F, 0x86, 0x97};
   PropNameID utf8PropNameID = PropNameID::forUtf8(rt, utf8, sizeof(utf8));
-  EXPECT_EQ(utf8PropNameID.utf8(rt), u8"\U0001F197");
+  // See about char8_t conversion: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r2.html
+  EXPECT_EQ(utf8PropNameID.utf8(rt), reinterpret_cast<const char *>(u8"\U0001F197"));
   EXPECT_TRUE(PropNameID::compare(
       rt, utf8PropNameID, PropNameID::forUtf8(rt, utf8, sizeof(utf8))));
   PropNameID nonUtf8PropNameID = PropNameID::forUtf8(rt, "meow");
@@ -518,7 +519,7 @@ TEST_P(JSITest, FunctionTest) {
                    "s1",
                    String::createFromAscii(rt, "s2"),
                    std::string{"s3"},
-                   std::string{u8"s\u2600"},
+                   std::string{reinterpret_cast<const char*>(u8"s\u2600")},
                    // invalid UTF8 sequence due to unexpected continuation byte
                    std::string{"s\x80"},
                    Object(rt),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 execute_process(
   COMMAND ${NUGET_EXE}
     install "Microsoft.JavaScript.Hermes"
-    -Version 0.1.12
+    -Version 0.1.13
     -ExcludeVersion
     -OutputDirectory ${CMAKE_BINARY_DIR}/packages
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
There were a few issues in the code that caused failures when compiled for C++20.
They are addressed in this PR:
- `u8""` strings in C++20 produce new `const char8_t*` string which is not compatible with `std::string`. The easiest solution is to `reinterpret_cast` it to `const char*`. See: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r2.html
- The `std::span` substitution had some incorrect APIs.
- Also updated the Hermes package version to 0.1.13.