### PR TITLE
Load all Hermes Inspector functions together

### DIFF
--- a/src/ApiLoaders/HermesApi.cpp
+++ b/src/ApiLoaders/HermesApi.cpp
@@ -9,8 +9,19 @@ namespace {
 
 struct HermesApiNames {
 #define HERMES_FUNC(func) static constexpr const char func[] = #func;
+#define HERMES_INSPECTOR_FUNC(func) HERMES_FUNC(func);
 #include "HermesApi.inc"
 };
+
+// Load all inspector functions together to ensure their availability from different threads.
+void loadInspectorFuncs() {
+  HermesApi *current = HermesApi::current();
+#define HERMES_INSPECTOR_FUNC(func)                                                                                  \
+  decltype(::func) *loaded_##func = reinterpret_cast<decltype(::func) *>(current->getFuncPtr(HermesApiNames::func)); \
+  size_t offset_##func = offsetof(HermesApi, func);                                                                  \
+  *reinterpret_cast<decltype(::func) **>(reinterpret_cast<char *>(current) + offset_##func) = loaded_##func;
+#include "HermesApi.inc"
+}
 
 } // namespace
 
@@ -19,7 +30,12 @@ thread_local HermesApi *HermesApi::current_{};
 HermesApi::HermesApi(IFuncResolver *funcResolver)
     : JSRuntimeApi(funcResolver)
 #define HERMES_FUNC(func) \
-  , func(&ApiFuncResolver<NodeApi, decltype(::func) *, HermesApiNames::func, offsetof(HermesApi, func)>::stub)
+  , func(&ApiFuncResolver<HermesApi, decltype(::func) *, HermesApiNames::func, offsetof(HermesApi, func)>::stub)
+#define HERMES_INSPECTOR_FUNC(func)                                                                           \
+  ,                                                                                                           \
+      func(&ApiFuncResolver<HermesApi, decltype(::func) *, HermesApiNames::func, offsetof(HermesApi, func)>:: \
+               preloadStub<&loadInspectorFuncs>)
+
 #include "HermesApi.inc"
 {
 }

--- a/src/ApiLoaders/HermesApi.h
+++ b/src/ApiLoaders/HermesApi.h
@@ -43,6 +43,7 @@ class HermesApi : public JSRuntimeApi {
 
  public:
 #define HERMES_FUNC(func) decltype(::func) *const func;
+#define HERMES_INSPECTOR_FUNC(func) HERMES_FUNC(func)
 #include "HermesApi.inc"
 
  private:

--- a/src/ApiLoaders/HermesApi.inc
+++ b/src/ApiLoaders/HermesApi.inc
@@ -4,7 +4,11 @@
 // The Hermes functions sorted alphabetically
 
 #ifndef HERMES_FUNC
-#error "HERMES_FUNC must exist before including this file"
+#define HERMES_FUNC(func)
+#endif
+
+#ifndef HERMES_INSPECTOR_FUNC
+#define HERMES_INSPECTOR_FUNC(func)
 #endif
 
 HERMES_FUNC(hermes_dump_crash_data)
@@ -15,9 +19,11 @@ HERMES_FUNC(hermes_sampling_profiler_remove)
 HERMES_FUNC(hermes_sampling_profiler_dump_to_file)
 HERMES_FUNC(hermes_config_enable_default_crash_handler)
 HERMES_FUNC(hermes_set_inspector)
-HERMES_FUNC(hermes_create_local_connection)
-HERMES_FUNC(hermes_delete_local_connection)
-HERMES_FUNC(hermes_local_connection_send_message)
-HERMES_FUNC(hermes_local_connection_disconnect)
+
+HERMES_INSPECTOR_FUNC(hermes_create_local_connection)
+HERMES_INSPECTOR_FUNC(hermes_delete_local_connection)
+HERMES_INSPECTOR_FUNC(hermes_local_connection_send_message)
+HERMES_INSPECTOR_FUNC(hermes_local_connection_disconnect)
 
 #undef HERMES_FUNC
+#undef HERMES_INSPECTOR_FUNC

--- a/src/ApiLoaders/JSRuntimeApi.cpp
+++ b/src/ApiLoaders/JSRuntimeApi.cpp
@@ -37,7 +37,7 @@ struct JSRuntimeApiNames {
 #include "JSRuntimeApi.inc"
 };
 
-// Prepared script function either should be all loaded or we use all default functions.
+// Prepared script functions either should be all loaded or we use all default functions.
 void loadPreparedScriptFuncs() {
   JSRuntimeApi *current = JSRuntimeApi::current();
   bool useDefault = false;


### PR DESCRIPTION
Hermes inspector functions can be used from different threads.
It may cause a failure when the loader API is not available in these threads.
Thus, in this PR we load them all together at the point when the loader API is available.