### PR TITLE
Remove unused parameters

### DIFF
--- a/jsi/jsi/test/testlib.cpp
+++ b/jsi/jsi/test/testlib.cpp
@@ -1448,7 +1448,7 @@ TEST_P(JSITest, ArrayBufferSizeTest) {
   try {
     // Ensure we can safely write some data to the buffer.
     memset(ab.data(rt), 0xab, 10);
-  } catch (const JSINativeException& ex) {
+  } catch (const JSINativeException&) {
     // data() is unimplemented by some runtimes, ignore such failures.
   }
 

--- a/src/NodeApiJsiRuntime.cpp
+++ b/src/NodeApiJsiRuntime.cpp
@@ -1573,7 +1573,7 @@ bool NodeApiJsiRuntime::instanceOf(const jsi::Object &obj, const jsi::Function &
 }
 
 #if JSI_VERSION >= 11
-void NodeApiJsiRuntime::setExternalMemoryPressure(const jsi::Object &obj, size_t amount) {
+void NodeApiJsiRuntime::setExternalMemoryPressure(const jsi::Object &/*obj*/, size_t /*amount*/) {
   // TODO: implement
 }
 #endif


### PR DESCRIPTION
Unused parameters cause compilation warnings and errors if the warnings are treated as errors.
This PR removes the unused parameters.