### PR TITLE
Fix jsi.h and update package versions in tests

### DIFF
--- a/jsi/jsi/README.md
+++ b/jsi/jsi/README.md
@@ -26,3 +26,15 @@ https://github.com/facebook/hermes repo.
 |       2 | `e0616e77e1ddc3ea5e2ccbca2e20dd0c4049c637` | Make it possible for a Runtime implementation to provide its own JSON parsing
 |       1 | `3ba9615f80913764ecb6456779d502e31dde9e5d` | Fix build break in MSVC (#26462)
 |       0 | `f22a18f67da3f03db59c1ec715d6ec3776b03fbf` | Initial commit
+
+Relationship to React Native versions:
+
+| RN Version | JSI version |
+|-----------:|------------:|
+|       main |          12 |
+|       0.74 |          11 |
+|       0.73 |          10 |
+|       0.72 |          10 |
+|       0.71 |           9 |
+|       0.70 |           6 |
+|       0.69 |           5 |

--- a/jsi/jsi/decorator.h
+++ b/jsi/jsi/decorator.h
@@ -567,6 +567,12 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::evaluatePreparedJavaScript(js);
   }
+#if JSI_VERSION >= 12
+  void queueMicrotask(const Function& callback) override {
+    Around around{with_};
+    RD::queueMicrotask(callback);
+  }
+#endif
 #if JSI_VERSION >= 4
   bool drainMicrotasks(int maxMicrotasksHint) override {
     Around around{with_};

--- a/jsi/jsi/jsi.h
+++ b/jsi/jsi/jsi.h
@@ -15,21 +15,19 @@
 #include <string>
 #include <vector>
 
-#ifndef JSI_EXPORT
-#ifdef _MSC_VER
-#ifdef CREATE_SHARED_LIBRARY
-#define JSI_EXPORT __declspec(dllexport)
-#else
-#define JSI_EXPORT
-#endif // CREATE_SHARED_LIBRARY
-#else // _MSC_VER
-#define JSI_EXPORT __attribute__((visibility("default")))
-#endif // _MSC_VER
-#endif // !defined(JSI_EXPORT)
-
 // JSI version defines set of features available in the API.
 // Each significant API change must be under a new version.
+// The JSI_VERSION can be provided as a parameter to compiler
+// or in the optional "jsi_version.h" file.
+
 #ifndef JSI_VERSION
+#if defined(__has_include) && __has_include(<jsi/jsi-version.h>)
+#include <jsi/jsi-version.h>
+#endif
+#endif
+
+#ifndef JSI_VERSION
+// Use the latest version by default
 #define JSI_VERSION 12
 #endif
 
@@ -44,6 +42,18 @@
 #else
 #define JSI_CONST_10
 #endif
+
+#ifndef JSI_EXPORT
+#ifdef _MSC_VER
+#ifdef CREATE_SHARED_LIBRARY
+#define JSI_EXPORT __declspec(dllexport)
+#else
+#define JSI_EXPORT
+#endif // CREATE_SHARED_LIBRARY
+#else // _MSC_VER
+#define JSI_EXPORT __attribute__((visibility("default")))
+#endif // _MSC_VER
+#endif // !defined(JSI_EXPORT)
 
 class FBJSRuntime;
 namespace facebook {
@@ -241,6 +251,7 @@ class JSI_EXPORT Runtime {
   /// \param callback a function to be executed as a microtask.
   virtual void queueMicrotask(const jsi::Function& callback) = 0;
 #endif
+
 #if JSI_VERSION >= 4
   /// Drain the JavaScript VM internal Microtask (a.k.a. Job in ECMA262) queue.
   ///
@@ -1592,6 +1603,7 @@ class JSI_EXPORT JSError : public JSIException {
     return *value_;
   }
 
+  //TODO: (vmoroz) Can we remove it considering that we have the new JSError constructor?
   // In V8's case, creating an Error object in JS doesn't record the callstack.
   // To preserve it, we need a way to manually add the stack here and on the JS
   // side.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 execute_process(
   COMMAND ${NUGET_EXE}
     install "Microsoft.JavaScript.Hermes"
-    -Version 0.1.18
+    -Version 0.1.27
     -ExcludeVersion
     -OutputDirectory ${CMAKE_BINARY_DIR}/packages
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
@@ -50,7 +50,7 @@ target_link_libraries(jsi_tests PRIVATE ${CMAKE_BINARY_DIR}/packages/Microsoft.J
 execute_process(
   COMMAND ${NUGET_EXE}
     install "ReactNative.V8Jsi.Windows"
-    -Version 0.71.12
+    -Version 0.75.4
     -ExcludeVersion
     -OutputDirectory ${CMAKE_BINARY_DIR}/packages
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
The `jsi.h` was missing ability to include `jsi_version.h` file and the `decorator.h` was missing the `queueMicrotask` method.
The unit tests are updated with the latest versions of v8-jsi and hermes-windows packages.